### PR TITLE
Add Hash Ring Support

### DIFF
--- a/lib/stores/hashring.js
+++ b/lib/stores/hashring.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var url = require('url'),
+    redis = require('redis'),
+    HashRing = require('hashring');
+
+function HashRingStore(servers) {
+    
+    var i,
+        temp;
+
+    if (!(this instanceof HashRingStore)) {
+        return new HashRingStore(servers);
+    }
+
+    if (typeof servers === 'string') {
+        servers = servers.split(',');
+    }
+
+    this.ring = new HashRing(servers);
+    this.client = {};
+
+    for (i = 0; i < servers.length; i++) {
+        temp = url.parse(servers[i]);
+        this.client[servers[i]] = redis.createClient(temp.port, temp.hostname);
+    }
+}
+
+HashRingStore.prototype.getClient = function cachingHashRingStoreGetServer(key) {
+
+    var server = this.ring.get(key),
+        client = this.client[server];
+    
+    return client;
+}
+
+HashRingStore.prototype.get = function(key, callback) {
+    this.getClient(key).get(key, function(err, result) {
+        callback(err, JSON.parse(result));
+    });
+};
+
+HashRingStore.prototype.set = function(key, ttl, result) {
+    if (ttl) {
+        this.getClient(key).setex(key, Math.ceil(ttl/1000), JSON.stringify(result));
+    } else {
+        this.getClient(key).set(key, JSON.stringify(result));
+    }
+};
+
+HashRingStore.prototype.remove = function(pattern) {
+    if (~pattern.indexOf('*')) {
+        var self = this;
+        this.getClient(pattern).keys(pattern, function(err, keys) {
+            if (keys.length) {
+                self.getClient(keys).del(keys);
+            }
+        });
+    } else {
+        this.getClient(pattern).del(pattern);
+    }
+};
+
+module.exports = HashRingStore;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "caching",
   "description": "Easier caching in node.js",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "author": "Mathias Pettersson <mape@mape.me>",
   "engines": [
     "node"
@@ -17,8 +17,9 @@
     }
   ],
   "dependencies": {
-    "hiredis" : ">=0.1.12",
-    "redis": ">=0.6.7"
+    "hiredis": ">=0.1.12",
+    "redis": ">=0.6.7",
+    "hashring": "~1.0.3"
   },
   "devDependencies": {
     "expresso": "~0.8.1"


### PR DESCRIPTION
Extend the Redis support to add a consistent hash ring that assumes the stores are Redis servers.
